### PR TITLE
fix: Fare type and period type ID selectors

### DIFF
--- a/src/main/java/uk/co/tfn/HelperMethods.java
+++ b/src/main/java/uk/co/tfn/HelperMethods.java
@@ -34,7 +34,7 @@ public class HelperMethods {
     }
 
     public static void getHomePage(WebDriver driver) {
-        driver.get("http://localhost:5555");
+        driver.get("https://tfn-test.infinityworks.com/");
     }
 
     public static DesiredCapabilities setCapabilities() {

--- a/src/main/java/uk/co/tfn/HelperMethods.java
+++ b/src/main/java/uk/co/tfn/HelperMethods.java
@@ -34,7 +34,7 @@ public class HelperMethods {
     }
 
     public static void getHomePage(WebDriver driver) {
-        driver.get("https://tfn-test.infinityworks.com");
+        driver.get("http://localhost:5555");
     }
 
     public static DesiredCapabilities setCapabilities() {

--- a/src/main/java/uk/co/tfn/StepMethods.java
+++ b/src/main/java/uk/co/tfn/StepMethods.java
@@ -21,9 +21,9 @@ public class StepMethods {
 
         continueButtonClick(driver);
 
-        waitForElement(driver, "fareType-single");
+        waitForElement(driver, "fare-type-single");
 
-        driver.findElement(By.id("fareType-single")).click();
+        driver.findElement(By.id("fare-type-single")).click();
 
         continueButtonClick(driver);
 
@@ -54,7 +54,7 @@ public class StepMethods {
 
         continueButtonClick(driver);
 
-        driver.findElement(By.id("fareType-period")).click();
+        driver.findElement(By.id("fare-type-period")).click();
 
         continueButtonClick(driver);
     }

--- a/src/test/java/uk/co/tfn/ChromeTestCase.java
+++ b/src/test/java/uk/co/tfn/ChromeTestCase.java
@@ -147,7 +147,7 @@ public class ChromeTestCase {
 
         stepsToPeriodPage(driver);
 
-        driver.findElement(By.id("periodtype-geo-zone")).click();
+        driver.findElement(By.id("period-type-geo-zone")).click();
 
         continueButtonClick(driver);
 
@@ -156,12 +156,12 @@ public class ChromeTestCase {
         submitButtonClick(driver);
 
         driver.findElement(By.id("numberOfProducts")).sendKeys("1");
-        
+
         continueButtonClick(driver);
 
-        driver.findElement(By.id("periodProductName")).sendKeys("Selenium Test Product");
+        driver.findElement(By.id("productDetailsName")).sendKeys("Selenium Test Product");
 
-        driver.findElement(By.id("periodProductPrice")).sendKeys("10.50");
+        driver.findElement(By.id("productDetailsPrice")).sendKeys("10.50");
 
         continueButtonClick(driver);
 
@@ -191,7 +191,7 @@ public class ChromeTestCase {
 
         stepsToPeriodPage(driver);
 
-        driver.findElement(By.id("periodtype-single-set-service")).click();
+        driver.findElement(By.id("period-type-single-set-service")).click();
 
         continueButtonClick(driver);
 
@@ -200,12 +200,12 @@ public class ChromeTestCase {
         continueButtonClick(driver);
 
         driver.findElement(By.id("numberOfProducts")).sendKeys("1");
-        
+
         continueButtonClick(driver);
 
-        driver.findElement(By.id("periodProductName")).sendKeys("Selenium Test Product");
+        driver.findElement(By.id("productDetailsName")).sendKeys("Selenium Test Product");
 
-        driver.findElement(By.id("periodProductPrice")).sendKeys("10.50");
+        driver.findElement(By.id("productDetailsPrice")).sendKeys("10.50");
 
         continueButtonClick(driver);
 
@@ -228,14 +228,14 @@ public class ChromeTestCase {
 
     @Test
     public void chromePeriodMultipleProducts() throws IOException {
-        
+
         getHomePage(driver);
 
         waitForPageToLoad(driver);
 
         stepsToPeriodPage(driver);
 
-        driver.findElement(By.id("periodtype-single-set-service")).click();
+        driver.findElement(By.id("period-type-single-set-service")).click();
 
         continueButtonClick(driver);
 


### PR DESCRIPTION
# Description

-   This PR fixes the IDs used as CSS selectors for the fareType page so that they are in line with changes made on the site by feature/TFN-406_flat_fare_user_journey.

# Testing instructions

-   Pull down this branch locally and run `./mvnw clean verify`. Validate 

# Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New test for full journey (non-breaking change)

# Checklist:

-   [X] Able to run pr locally
-   [X] Followed test acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
