### PR TITLE
Fixed IE problem

### DIFF
--- a/src/main/java/uk/co/tfn/HelperMethods.java
+++ b/src/main/java/uk/co/tfn/HelperMethods.java
@@ -773,12 +773,20 @@ public class HelperMethods {
         int randomNumberOfCheckboxesToClick = randomNumberBetweenOneAnd(numberOfCheckboxes);
 
         for (int i = 0; i < randomNumberOfCheckboxesToClick; i++) {
-            operatorCheckboxes.get(i).click();
+            if (this.browser.equals("ie")) {
+                javascriptClick(operatorCheckboxes.get(i));
+            } else {
+                operatorCheckboxes.get(i).click();
+            }
         }
         this.clickElementById("add-operator-button");
         this.waitForPageToLoad();
         if(randomNumberOfCheckboxesToClick > 1 && randomNumberBetweenOneAnd(2) == 1) {
-            this.clickElementById("remove-operator-checkbox-0");
+            if (this.browser.equals("ie")) {
+                javascriptClick(driver.findElement(By.id("remove-operator-checkbox-0")));
+            } else {
+                this.clickElementById("remove-operator-checkbox-0");
+            }
             this.clickElementById("remove-operators-button");
             this.waitForPageToLoad();
             return randomNumberOfCheckboxesToClick - 1;


### PR DESCRIPTION
# Description

-   IE checkboxes were not being clicked properly on the search operators page.

# Testing instructions

-   Use browserstack local to run on IE.

# Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New test for full journey (non-breaking change)

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed test acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
